### PR TITLE
Use `uv` in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,10 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 3
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
     groups:
       dev-dependencies:
-        patterns:
-          - "*"
+        dependency-type: "development"


### PR DESCRIPTION
`pip` wasn't really working; need to use `uv`.